### PR TITLE
Changed Route from going back to default route based on role on unaut…

### DIFF
--- a/src/Features/Unauthorized/index.js
+++ b/src/Features/Unauthorized/index.js
@@ -32,7 +32,7 @@ const Unauthorized = () => {
               const defaultRouteAfterLogin = defaultRouteForRoles[role];
               history.push(defaultRouteAfterLogin || '/');
             }}
-            property="GO To Default Route"
+            property="Go To Default Route"
           />
         </Grid>
       </Grid>

--- a/src/Features/Unauthorized/index.js
+++ b/src/Features/Unauthorized/index.js
@@ -2,11 +2,20 @@ import React from 'react';
 
 import { Grid, Box } from '@material-ui/core';
 import Typography from '@material-ui/core/Typography';
+import { useSelector } from 'react-redux';
 import { useHistory } from 'react-router';
 
 import Button from '../../components/Button/Button';
+import { defaultRouteForRoles } from '../../scripts/constants';
 
 const Unauthorized = () => {
+  const role = useSelector((state) => {
+    const {
+      authReducer: { role },
+    } = state;
+    return role;
+  });
+
   const history = useHistory();
 
   return (
@@ -20,9 +29,10 @@ const Unauthorized = () => {
         <Grid item>
           <Button
             onClick={() => {
-              history.goBack();
+              const defaultRouteAfterLogin = defaultRouteForRoles[role];
+              history.push(defaultRouteAfterLogin || '/');
             }}
-            property="GO BACK"
+            property="GO To Default Route"
           />
         </Grid>
       </Grid>


### PR DESCRIPTION
## GOAL && WORK

Changed Route from going back to default route based on role on unauthorized page. The reason of doing so, because if there is no history present, it doesn't go anywhere and in PWA environment, we do not have access to changing URL,  so we can't change page manually and going back wasn't working. Going to default route, I think is better.